### PR TITLE
Be more verbose about the detected configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Author: Stefan Haun <tux@netz39.de>
 
 import signal
@@ -11,6 +10,7 @@ import mqtt
 
 import sensors
 
+import logging
 import util
 
 running = True
@@ -30,7 +30,7 @@ def sigint_handler(_signal, _frame):
 def emit_labels(mqtt_client, mqtt_prefix, cfg_chips):
     for chip in cfg_chips:
         features = cfg_chips.get(chip, list())
-        for feature in features['features'].values():
+        for feature_name, feature in features['features'].items():
             topic = mqtt_prefix + feature['mqtt']
             label = feature.get('label')
             if label is not None:
@@ -38,6 +38,8 @@ def emit_labels(mqtt_client, mqtt_prefix, cfg_chips):
                     "{}/Label".format(topic),
                     label
                 )
+            else:
+                logging.warning("No label found for %s/%s" % (chip, feature_name))
 
 
 def emit_chip_values(mqtt_client, mqtt_prefix, cfg_chips, sensor_chip):

--- a/app.py
+++ b/app.py
@@ -85,6 +85,7 @@ def main():
     finally:
         sensors.cleanup()
 
+    # noinspection PyUnreachableCode
     if mqtt_client.is_connected():
         mqtt_client.loop_stop()
 

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ def main():
     signal.signal(signal.SIGINT, sigint_handler)
 
     mqtt_config = mqtt.MqttConfig.from_env("MQTT_")
+    print("Running with MQTT config:", mqtt_config)
     mqtt_client = mqtt.create_client(mqtt_config)
 
     mqtt_prefix = mqtt_config.prefix
@@ -88,6 +89,8 @@ def main():
     # noinspection PyUnreachableCode
     if mqtt_client.is_connected():
         mqtt_client.loop_stop()
+
+    print("Exiting.")
 
 
 if __name__ == '__main__':

--- a/mqtt.py
+++ b/mqtt.py
@@ -25,6 +25,9 @@ class MqttConfig:
     def prefix(self):
         return self._prefix
 
+    def __str__(self):
+        return f"MqttConfig(host={self._host}, prefix={self._prefix})"
+
 
 MQTT_TOPICS = []
 


### PR DESCRIPTION
This pull request introduces enhancements to logging and error handling in the `app.py` script and improves the `MqttConfig` class in `mqtt.py` for better debugging. The most significant changes include adding logging for missing labels, printing the MQTT configuration and exit status, and implementing a `__str__` method for the `MqttConfig` class.

### Logging and error handling improvements in `app.py`:
* Added a warning message in `emit_labels` to log cases where a label is missing for a specific chip and feature. (`app.py`, [app.pyL33-R42](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L33-R42))
* Added a print statement in `main` to display the MQTT configuration being used, aiding in debugging. (`app.py`, [app.pyR65](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R65))
* Added a print statement in `main` to indicate when the application is exiting. (`app.py`, [app.pyR91-R96](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R91-R96))

### Debugging enhancement in `mqtt.py`:
* Added a `__str__` method to the `MqttConfig` class to provide a human-readable string representation of the configuration, making it easier to debug. (`mqtt.py`, [mqtt.pyR28-R30](diffhunk://#diff-26aadb984a310fe79440f307b9aeccb0c550911ae971bfad69f5f4721e0234feR28-R30))