### PR TITLE
Adjust docker-image workflow for new main branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,12 +3,12 @@ name: Docker Image
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - 'v*'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   docker:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to reflect the branch name change from `master` to `main`.

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL6-R11): Updated the branch references in the `push` and `pull_request` triggers to use `main` instead of `master`.