### PR TITLE
Add a file data provider to read values from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ The following environment variables are expected:
         "chip": "<chip name>",
         "feature": "<feature name>"
       }
+    },
+    {
+      "label": "<sensor feature label>",
+      "topic": "<feature mqtt topic (added to prefix)>",
+      "file": {
+        "path": "<file path to read>"
+      }
     }
   ]
 }
@@ -27,6 +34,15 @@ The following environment variables are expected:
 
 In the above example, anything listed as `<...>` is meant to be replaced by a value described by the label with the brackets, e.g. `<chip name>` is written as `coretemp-isa-0000` without the brackets.
 The top "sensors" object may seem redundant, but allows for future expansion of the configuration.
+
+### Data Providers
+
+The following data providers are available:
+* **lm-sensors**: Reads the value from the lm-sensors chip and feature name.
+  * `chip`: The name of the chip as shown by `sensors -l`
+  * `feature`: The name of the feature as shown by `sensors -l` 
+* **file**: Reads the value from a file.
+  * `path`: The path to the file to read. The file must contain a single line with the value to be read. A final newline will be stripped.
 
 ## Running
 

--- a/app.py
+++ b/app.py
@@ -49,7 +49,8 @@ def verify_sensor_config(cfg):
 
     # Define required fields for each configuration type
     PROVIDER_FIELDS = {
-        "lm-sensors": ["chip", "feature"]
+        "lm-sensors": ["chip", "feature"],
+        "file": ["path"]
     }
 
     if not isinstance(cfg, dict):

--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ import mqtt
 import logging
 import util
 
-from providers import LmSensorsDataProvider
+from providers import LmSensorsDataProvider, FileDataProvider
 from sensor_data_event import SensorDataEvent
 
 running = True
@@ -172,6 +172,10 @@ def main():
     # Add lm-sensors provider
     lm_sensors_provider = LmSensorsDataProvider(cfg_sensors['sensors'])
     providers.append(lm_sensors_provider)
+    # Add file providers
+    for sensor in (s for s in cfg_sensors['sensors'] if s.get('file')):
+        file_provider = FileDataProvider(sensor)
+        providers.append(file_provider)
 
     while running:
         # Collect sensor data


### PR DESCRIPTION
This pull request introduces a new data provider for reading sensor data from files, alongside updates to the documentation and application logic to support this functionality. The most significant changes include the addition of the `FileDataProvider` class, updates to the configuration validation, and enhancements to the documentation to describe the new provider.

This PR enables a workaround for #10 

### New Feature: File-Based Data Provider
* Added the `FileDataProvider` class in `providers.py`, which reads sensor data from a file specified in the sensor configuration. It validates the file path and handles errors gracefully during data retrieval. [[1]](diffhunk://#diff-3915366f57ea888d7185d276dc4536dfbd08de9b3965039374a2a3cce6c18c50R1) [[2]](diffhunk://#diff-3915366f57ea888d7185d276dc4536dfbd08de9b3965039374a2a3cce6c18c50R108-R144)
* Updated `app.py` to import `FileDataProvider`, validate the presence of the `path` field in configurations for file-based sensors, and initialize file providers in the `main` function. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L15-R15) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L52-R53) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R175-R178)

### Documentation Updates
* Expanded the `README.md` to include details about the new file-based data provider, describing its configuration fields and usage.
* Updated the example configuration in `README.md` to include a sample entry for a file-based sensor.