### PR TITLE
Docker-compose related updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ With the configuration stored in a file `.env`, the tool can be started as follo
 ```bash
 docker run --rm \
   --env-file .env \
-  mrtux/sensors-report
+  mrtux/sensors-report:latest
 ```
 
-Alternatively there is a `docker-compose` set up to build and run from the repository.
+Please replace `latest` with the version you want to run. The latest version is not guaranteed to be stable.
 
-For production use pre-built docker images are recommended.
+Alternatively there is a `docker compose` set up to build and run from the repository.
+For production use [pre-built docker images](https://hub.docker.com/r/mrtux/sensors-report/) are recommended.
 
 ## Contributions
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,6 @@ services:
         environment:
           MQTT_HOST: $MQTT_HOST
           MQTT_PREFIX: $MQTT_PREFIX
+        volumes:
+            - /tmp:/tmp:r
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # Do not forget to create the .env file (see template)
 # before using this container!
 
-version: '2'
 
 services:
     sensors-report:


### PR DESCRIPTION
This pull request includes updates to the documentation and configuration files for the `sensors-report` tool. The changes improve clarity in the README, update the `docker-compose.yml` file, and enhance usability by providing additional instructions and configuration options.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R60): Updated the Docker command to specify the `:latest` tag explicitly and added a note advising users to replace `latest` with a specific version for stability. Also, provided a link to pre-built Docker images on Docker Hub and clarified the usage of `docker compose` instead of `docker-compose`.

### Configuration updates:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L4): Removed the version declaration (`version: '2'`) to align with newer Docker Compose practices.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R14-R15): Added a volume mapping (`/tmp:/tmp:r`) to the `sensors-report` service to allow temporary file sharing.