### PR TITLE
Change the data content of CloudEvents for privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ The report is emitted as a [CloudEvents](https://cloudevents.io/) message. The f
   "subject": "<The sensor's topic>",
   "datacontenttype": "application/json",
   "data": {
-    "sensor_config": "<The sensor config dictionary is repeated here as JSON value>",
+    "topic": "<The sensor's topic>",
+    "label": "<The sensor's label, if configured>",
     "value": "<Measured sensor value>"
   }
 }
 ```
+The sensor's topic is mirrored to the subject attribute to allow out-of-band filtering of the messages with intermediary handlers.
 
 ## Running
 

--- a/sensor_data_event.py
+++ b/sensor_data_event.py
@@ -1,6 +1,3 @@
-from cloudevents import CloudEventGenerator
-
-
 class SensorDataEvent:
     """
     Represents a measurement from one sensor.
@@ -27,7 +24,8 @@ class SensorDataEvent:
         return generator.generate(
             subject=self.sensor_config['topic'],
             data={
-                "sensor_config": self.sensor_config,
+                "topic": self.sensor_config['topic'],
+                "label": self.sensor_config['label'],
                 "value": self.value
             })
 


### PR DESCRIPTION
This pull request changes the content  of CloudEvents to avoid sending sensitive configuration data.

### Updates to CloudEvents message structure:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L63-R69): Updated the example CloudEvents message to replace the `sensor_config` dictionary with individual fields (`topic`, `label`, and `value`). Added a note explaining that the `topic` is mirrored to the `subject` attribute for easier filtering.
* [`sensor_data_event.py`](diffhunk://#diff-8a44f4e93acdc6d315cd587c9768e47bad1c0d5df8847e020ab0ce5cd0b12970L30-R28): Updated the `as_cloud_event_data` method to replace the `sensor_config` dictionary with specific fields (`topic`, `label`, and `value`) in the event data. The `label` field is included only if configured.

### Code cleanup:

* [`sensor_data_event.py`](diffhunk://#diff-8a44f4e93acdc6d315cd587c9768e47bad1c0d5df8847e020ab0ce5cd0b12970L1-L3): Removed an unused import of `CloudEventGenerator`.