### PR TITLE
Fix that MQTT topics would have double or missing slashes

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -70,3 +70,19 @@ def create_client(mqtt_config, on_disconnect_cb=None):
 
     return client
 
+def join_topics(prefix, *subtopics):
+    """
+    Joins an MQTT topic prefix with one or more subtopics, ensuring exactly one slash between each part.
+    Preserves leading slashes in the topic prefix.
+
+    Args:
+        prefix (str): The MQTT topic prefix.
+        *subtopics (str): One or more MQTT subtopics.
+
+    Returns:
+        str: The combined MQTT topic.
+    """
+    # Strip slashes from the ends of subtopics and join them with a single slash
+    middle = "/".join(subtopic.strip("/") for subtopic in subtopics)
+    # Combine prefix and middle, preserving leading slashes
+    return f"{prefix.rstrip('/')}/{middle}" if middle else prefix


### PR DESCRIPTION
This pull request refactors MQTT topic handling in the `app.py` file by introducing a new utility function, `join_topics`, in `mqtt.py`. This change ensures consistent formatting of MQTT topics, fixing issues with missing or double slashes in the topic hierarchy, and reduces code duplication.

### Refactoring MQTT topic handling:

* [`mqtt.py`](diffhunk://#diff-26aadb984a310fe79440f307b9aeccb0c550911ae971bfad69f5f4721e0234feR73-R84): Added the `join_topics` function to concatenate MQTT topic prefixes and subtopics, ensuring exactly one slash between them.
* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L111-R112): Updated the `emit_labels`, `emit_sensor_data_event`, and `emit_cloudevent` functions to use the new `join_topics` utility for constructing MQTT topics. This replaces manual string concatenation and ensures consistent formatting. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L111-R112) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L129-R130) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L149-R150)
