### PR TITLE
Rewrite docker-image workflow to emit artifact attestations

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,18 +10,28 @@ on:
     branches:
       - 'main'
 
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: mrtux/sensors-report
+  TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
-          images: mrtux/sensors-report
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             # 1.2.3
             type=semver,pattern={{version}}
@@ -31,23 +41,35 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        
+
       - name: Build and push
-        uses: docker/build-push-action@v2
+        id: push
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # Use all platforms on push and tags, otherwise limit to linux/amd64 for faster CI
+          platforms: ${{ github.event_name != 'pull_request' && env.TARGET_PLATFORMS || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        # The digest is only available after a push
+        # Limit to tagged releases to avoid attesting every single merge to main
+        if: startsWith(github.ref, 'refs/tags/v') && steps.push.outputs.digest != ''
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
This pull request updates the Docker image GitHub Actions workflow to modernize dependencies, improve multi-platform support, and enhance supply chain security. The most important changes include upgrading all Docker-related actions to their latest major versions, introducing environment variables for configuration, optimizing platform selection for CI, and adding artifact attestation for tagged releases.

**Dependency Upgrades:**

* Upgraded all Docker-related GitHub Actions to their latest major versions (`actions/checkout@v5`, `docker/metadata-action@v5`, `docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v6`) for improved performance and security. [[1]](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cR13-R34) [[2]](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL34-R75)

**Configuration Improvements:**

* Added environment variables (`REGISTRY`, `IMAGE_NAME`, `TARGET_PLATFORMS`) to simplify and centralize configuration for image naming and platform targeting.

**Multi-Platform Build Optimization:**

* Optimized the `platforms` parameter to use all target platforms for pushes and tags, but limit to `linux/amd64` for pull requests to speed up CI.

**Security and Provenance:**

* Added job permissions for packages, contents, attestations, and id-token to enable secure artifact attestation and registry operations.
* Introduced a step to generate artifact attestation using `actions/attest-build-provenance@v3` for tagged releases, enhancing supply chain security by verifying build provenance.