### PR TITLE
Set up Dependabot weekly runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: "Generate release changelog"
@@ -26,7 +26,7 @@ jobs:
         id: get-version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: "Create GitHub release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           name: "${{ steps.get-version.outputs.VERSION }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.13
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
This pull request introduces several updates to CI/CD configuration and the Docker build environment. The main changes are focused on modernizing dependencies, improving automation for dependency updates, and upgrading the Python version used in the Docker image.

**CI/CD configuration updates:**

* Added a new `.github/dependabot.yml` file to enable automated weekly dependency updates for GitHub Actions, Docker, and pip dependencies.
* Updated the GitHub Actions workflow in `.github/workflows/release.yml` to use newer versions of `actions/checkout` (v5) and `softprops/action-gh-release` (v2), ensuring compatibility and access to the latest features and security fixes. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R14) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L29-R29)

**Environment update:**

* Upgraded the base Python image in `Dockerfile` from `python:3.12` to `python:3.13`, providing access to the latest language features and improvements.